### PR TITLE
Tests exception names and reasons instead of using the exception class matcher

### DIFF
--- a/IntegrationSpecs/SwizzleanIntegrationSpec.mm
+++ b/IntegrationSpecs/SwizzleanIntegrationSpec.mm
@@ -86,7 +86,7 @@ describe(@"SwizzleanIntegration", ^{
                     [swizz swizzleInstanceMethod:deftonesTrackSEL withReplacementImplementation:^(id self) {
                         return @"This doesn't matter";
                     }];
-                } should raise_exception([NSException exceptionWithName:@"Swizzlean" reason:reasonStr userInfo:nil]);
+                } should raise_exception.with_name(@"Swizzlean").with_reason(reasonStr);
             });
             
             it(@"throws exception when attempting to reset an unswizzled instance method", ^{
@@ -160,7 +160,7 @@ describe(@"SwizzleanIntegration", ^{
                     [swizz swizzleClassMethod:deftonesTrackSEL withReplacementImplementation:^(id self) {
                         return @"This doesn't matter";
                     }];
-                } should raise_exception([NSException exceptionWithName:@"Swizzlean" reason:reasonStr userInfo:nil]);
+                } should raise_exception.with_name(@"Swizzlean").with_reason(reasonStr);
             });
             
             it(@"throws exception when attempting to reset an unswizzled class method", ^{

--- a/Specs/SwizzleanSpec.mm
+++ b/Specs/SwizzleanSpec.mm
@@ -109,7 +109,7 @@ describe(@"Swizzlean", ^{
                     NSString *reasonStr = [NSString stringWithFormat:@"Instance method doesn't exist: %@", methodName];
                     ^{
                         [swizzleanObj swizzleInstanceMethod:tacoMethodSEL withReplacementImplementation:replacementImpBlock];
-                    } should raise_exception([NSException exceptionWithName:@"Swizzlean" reason:reasonStr userInfo:nil]);
+                    } should raise_exception.with_name(@"Swizzlean").with_reason(reasonStr);
                 });
             });
             
@@ -260,7 +260,7 @@ describe(@"Swizzlean", ^{
                     NSString *reasonStr = [NSString stringWithFormat:@"Class method doesn't exist: %@", methodName];
                     ^{
                         [swizzleanObj swizzleClassMethod:burritoMethodSEL withReplacementImplementation:replacementImpBlock];
-                    } should raise_exception([NSException exceptionWithName:@"Swizzlean" reason:reasonStr userInfo:nil]);
+                    } should raise_exception.with_name(@"Swizzlean").with_reason(reasonStr);
                 });
             });
             


### PR DESCRIPTION
The format which was previously used to test exceptions was meant for testing the exception class. An example use case would be 
`^{ ... } should raise_exception([NSInternalInconsistencyException class]);`
In order to test the actual contents of an exception, `.with_name( ... )` and `.with_reason( ... )` must be used. 
